### PR TITLE
[ACS-2008] Upgrade libraries

### DIFF
--- a/lucene/ivy-versions.properties
+++ b/lucene/ivy-versions.properties
@@ -138,7 +138,7 @@ org.apache.directory.server.version = 2.0.0-M15
 /org.apache.directory.server/apacheds-protocol-shared = ${org.apache.directory.server.version}
 /org.apache.directory.server/apacheds-xdbm-partition = ${org.apache.directory.server.version}
 
-org.apache.hadoop.version = 2.7.4
+org.apache.hadoop.version = 2.7.7
 /org.apache.hadoop/hadoop-annotations = ${org.apache.hadoop.version}
 /org.apache.hadoop/hadoop-auth = ${org.apache.hadoop.version}
 /org.apache.hadoop/hadoop-common = ${org.apache.hadoop.version}

--- a/lucene/ivy-versions.properties
+++ b/lucene/ivy-versions.properties
@@ -3,7 +3,7 @@
 # when the lexical sort check is performed by the ant check-lib-versions target.
 
 /antlr/antlr = 2.7.7
-/com.adobe.xmp/xmpcore = 5.1.2
+/com.adobe.xmp/xmpcore = 5.1.3
 
 com.carrotsearch.randomizedtesting.version = 2.5.0
 /com.carrotsearch.randomizedtesting/junit4-ant = ${com.carrotsearch.randomizedtesting.version}

--- a/lucene/ivy-versions.properties
+++ b/lucene/ivy-versions.properties
@@ -173,7 +173,7 @@ org.apache.poi.version = 3.17-beta1
 /org.apache.poi/poi-ooxml-schemas = ${org.apache.poi.version}
 /org.apache.poi/poi-scratchpad = ${org.apache.poi.version}
 
-org.apache.tika.version = 1.16
+org.apache.tika.version = 1.27
 /org.apache.tika/tika-core = ${org.apache.tika.version}
 /org.apache.tika/tika-java7 = ${org.apache.tika.version}
 /org.apache.tika/tika-parsers = ${org.apache.tika.version}


### PR DESCRIPTION
The goal of this PR is to upgrade the libraries below and release a new patched version:

- Apache Hadoop from 2.7.4 to 2.7.7
- Apache Tika from 1.16 to 1.27
- Adobe Xmpcore from 5.1.2 to 5.1.3

cc @vrmoreira 